### PR TITLE
error in url redirect for https://faker.js/dev

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,7 +8,7 @@ Documentation is a crucial aspect of software development that is often neglecte
 
 ## Definition
 
-[VitePress](https://vitepress.vuejs.org/) is a simple and performant static site generator built on top of [Vite](https://vitejs.dev) for creating docs in a matter of minutes. It is powered by [Vuejs](https://vuejs.org/), and Vite with built in customizable components. VitePress powers some popular documentation sites like Vuejs, [Vitest](https://vitest.dev/), [faker.js](https://faker.js/dev), and Vite itself.
+[VitePress](https://vitepress.vuejs.org/) is a simple and performant static site generator built on top of [Vite](https://vitejs.dev) for creating docs in a matter of minutes. It is powered by [Vuejs](https://vuejs.org/), and Vite with built in customizable components. VitePress powers some popular documentation sites like Vuejs, [Vitest](https://vitest.dev/), [faker.js](https://fakerjs.dev/), and Vite itself.
 
 ## Prerequisites
 


### PR DESCRIPTION
- not trying to be the programming equivalent of a grammar Nazi but just thought id correct  the URL for [__`faker.js`__](https://fakerjs.dev/) from the original [__`faker.js`__](https://fakerjs.dev)

the same mistake is also present on your freecodecamp blog (nice blog btw)